### PR TITLE
ci: deploy branch preview docs only on main repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -350,11 +350,11 @@ jobs:
         path: docs/_build/.jupyter_cache
 
   branch-preview:
+    # We can only deploy for PRs on host repo
+    if: github.repository_owner == 'scikit-hep'
     runs-on: ubuntu-22.04
     needs: [build-docs]
     name: Deploy Branch Preview
-    # We can only deploy for PRs on host repo
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Forked repositories normally do not have secrets correctly configured See
https://github.com/orgs/community/discussions/26409#discussioncomment-3251822